### PR TITLE
House Keeping

### DIFF
--- a/src/CurlGenerator.Core/ScriptFileGenerator.cs
+++ b/src/CurlGenerator.Core/ScriptFileGenerator.cs
@@ -227,7 +227,6 @@ public static class ScriptFileGenerator
         {
             using var writer = new StreamWriter(LogFilePath, true);
             writer.WriteLine($"{DateTime.Now}: {message}");
-
         }
         catch
         {

--- a/src/CurlGenerator.Tests/SwaggerPetstoreTests.cs
+++ b/src/CurlGenerator.Tests/SwaggerPetstoreTests.cs
@@ -21,14 +21,6 @@ public class SwaggerPetstoreTests
     [InlineData(Samples.PetstoreYamlV3, "SwaggerPetstore.yaml")]
     [InlineData(Samples.PetstoreJsonV2, "SwaggerPetstore.json")]
     [InlineData(Samples.PetstoreYamlV2, "SwaggerPetstore.yaml")]
-    [InlineData(Samples.PetstoreJsonV3, "SwaggerPetstore.json")]
-    [InlineData(Samples.PetstoreYamlV3, "SwaggerPetstore.yaml")]
-    [InlineData(Samples.PetstoreJsonV2, "SwaggerPetstore.json")]
-    [InlineData(Samples.PetstoreYamlV2, "SwaggerPetstore.yaml")]
-    [InlineData(Samples.PetstoreJsonV3WithDifferentHeaders, "SwaggerPetstore.json")]
-    [InlineData(Samples.PetstoreYamlV3WithDifferentHeaders, "SwaggerPetstore.yaml")]
-    [InlineData(Samples.PetstoreJsonV2WithDifferentHeaders, "SwaggerPetstore.json")]
-    [InlineData(Samples.PetstoreYamlV2WithDifferentHeaders, "SwaggerPetstore.yaml")]
     [InlineData(Samples.PetstoreJsonV3WithDifferentHeaders, "SwaggerPetstore.json")]
     [InlineData(Samples.PetstoreYamlV3WithDifferentHeaders, "SwaggerPetstore.yaml")]
     [InlineData(Samples.PetstoreJsonV2WithDifferentHeaders, "SwaggerPetstore.json")]
@@ -47,10 +39,6 @@ public class SwaggerPetstoreTests
     }
 
     [Theory]
-    [InlineData(HttpsUrlPrefix + "petstore.json")]
-    [InlineData(HttpsUrlPrefix + "petstore.yaml")]
-    [InlineData(HttpUrlPrefix + "petstore.json")]
-    [InlineData(HttpUrlPrefix + "petstore.yaml")]
     [InlineData(HttpsUrlPrefix + "petstore.json")]
     [InlineData(HttpsUrlPrefix + "petstore.yaml")]
     [InlineData(HttpUrlPrefix + "petstore.json")]
@@ -74,10 +62,6 @@ public class SwaggerPetstoreTests
     }
 
     [Theory]
-    [InlineData(HttpsUrlPrefix + "petstore.json")]
-    [InlineData(HttpsUrlPrefix + "petstore.yaml")]
-    [InlineData(HttpUrlPrefix + "petstore.json")]
-    [InlineData(HttpUrlPrefix + "petstore.yaml")]
     [InlineData(HttpsUrlPrefix + "petstore.json")]
     [InlineData(HttpsUrlPrefix + "petstore.yaml")]
     [InlineData(HttpUrlPrefix + "petstore.json")]


### PR DESCRIPTION
This pull request refactors the `Log()` method in the `ScriptFileGenerator` class to `TryLog()` and removes duplicate `[InlineData]` arguments. The `TryLog()` method now ignores IO errors, improving the code's error handling. Additionally, extra whitespace has been removed from the code. These changes enhance the readability and maintainability of the codebase.