### PR TITLE
Only remove the last character when there are query string parameters

### DIFF
--- a/src/CurlGenerator.Core/ScriptFileGenerator.cs
+++ b/src/CurlGenerator.Core/ScriptFileGenerator.cs
@@ -272,7 +272,10 @@ public static class ScriptFileGenerator
                 url += $"{parameterName.Key}=${value}&";
             }
 
-            url = url.Remove(url.Length - 1);
+            if (parameterNameMap.Count > 0)
+            {
+                url = url.Remove(url.Length - 1);
+            }
         }
 
         code.AppendLine($"curl -X {verb.ToUpperInvariant()} {baseUrl}{url} `");


### PR DESCRIPTION
This resolves #211 

This pull request makes a minor improvement to the `GenerateRequest` method in `ScriptFileGenerator.cs` by ensuring that the trailing character is removed from the URL only if there are parameters present. This prevents potential errors when no parameters are provided.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed URL construction when no query parameters are present, preventing accidental truncation of the final character in the path.
  * Ensures the “?” is only added when parameters exist and that parameter joining remains correct.
  * Improves reliability of generated requests and prevents malformed URLs, reducing failed executions in scripts and tools that rely on these URLs.
  * No changes to public APIs or user-facing configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->