### PR TITLE
Improve code coverage

### DIFF
--- a/src/CurlGenerator.Core/CurlGenerator.Core.csproj
+++ b/src/CurlGenerator.Core/CurlGenerator.Core.csproj
@@ -17,4 +17,8 @@
     <PackageReference Include="Microsoft.Extensions.Azure" Version="1.12.0" />
   </ItemGroup>
 
+  <ItemGroup>
+    <InternalsVisibleTo Include="CurlGenerator.Tests" />
+  </ItemGroup>
+
 </Project>

--- a/src/CurlGenerator.Tests/OpenApiStatsTests.cs
+++ b/src/CurlGenerator.Tests/OpenApiStatsTests.cs
@@ -1,0 +1,69 @@
+
+using CurlGenerator.Validation;
+using FluentAssertions;
+using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi.Services;
+
+namespace CurlGenerator.Tests;
+
+public class OpenApiStatsTests
+{
+    [Fact]
+    public void Visit_FullOpenApiDocument_CorrectlyCountsAllElements()
+    {
+        // Arrange
+        var document = new OpenApiDocument
+        {
+            Paths = new OpenApiPaths
+            {
+                ["/test"] = new OpenApiPathItem
+                {
+                    Operations = new Dictionary<OperationType, OpenApiOperation>
+                    {
+                        [OperationType.Get] = new OpenApiOperation
+                        {
+                            Parameters = { new OpenApiParameter { In = ParameterLocation.Query, Name = "param1" } },
+                            RequestBody = new OpenApiRequestBody(),
+                            Responses = new OpenApiResponses
+                            {
+                                ["200"] = new OpenApiResponse
+                                {
+                                    Headers = new Dictionary<string, OpenApiHeader>
+                                    {
+                                        ["X-Rate-Limit"] = new OpenApiHeader()
+                                    }
+                                }
+                            },
+                            Callbacks = new Dictionary<string, OpenApiCallback> { ["onData"] = new OpenApiCallback() }
+                        }
+                    }
+                }
+            },
+            Components = new OpenApiComponents
+            {
+                Schemas = { ["mySchema"] = new OpenApiSchema() },
+                Links = { ["myLink"] = new OpenApiLink() }
+            }
+        };
+
+        var stats = new OpenApiStats();
+        var walker = new OpenApiWalker(stats);
+
+        // Act
+        walker.Walk(document);
+
+        // Assert
+        stats.PathItemCount.Should().Be(1);
+        stats.OperationCount.Should().Be(1);
+        stats.ParameterCount.Should().Be(1);
+        stats.RequestBodyCount.Should().Be(1);
+        stats.ResponseCount.Should().Be(1);
+        stats.LinkCount.Should().Be(1);
+        stats.CallbackCount.Should().Be(1);
+        stats.SchemaCount.Should().Be(1);
+        stats.HeaderCount.Should().Be(1);
+
+        ;
+        
+    }
+}

--- a/src/CurlGenerator.Tests/OpenApiStatsTests.cs
+++ b/src/CurlGenerator.Tests/OpenApiStatsTests.cs
@@ -63,7 +63,5 @@ public class OpenApiStatsTests
         stats.SchemaCount.Should().Be(1);
         stats.HeaderCount.Should().Be(1);
 
-        ;
-        
     }
 }

--- a/src/CurlGenerator.Tests/OpenApiValidationResultTests.cs
+++ b/src/CurlGenerator.Tests/OpenApiValidationResultTests.cs
@@ -1,0 +1,56 @@
+
+using CurlGenerator.Validation;
+using FluentAssertions;
+using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi.Readers;
+
+namespace CurlGenerator.Tests;
+
+public class OpenApiValidationResultTests
+{
+    [Fact]
+    public void IsValid_WithNoErrors_ReturnsTrue()
+    {
+        var diagnostics = new OpenApiDiagnostic();
+        var stats = new OpenApiStats();
+        var result = new OpenApiValidationResult(diagnostics, stats);
+
+        result.IsValid.Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsValid_WithErrors_ReturnsFalse()
+    {
+        var diagnostics = new OpenApiDiagnostic();
+        diagnostics.Errors.Add(new OpenApiError("", "Error"));
+        var stats = new OpenApiStats();
+        var result = new OpenApiValidationResult(diagnostics, stats);
+
+        result.IsValid.Should().BeFalse();
+    }
+
+    [Fact]
+    public void ThrowIfInvalid_WithNoErrors_DoesNotThrow()
+    {
+        var diagnostics = new OpenApiDiagnostic();
+        var stats = new OpenApiStats();
+        var result = new OpenApiValidationResult(diagnostics, stats);
+
+        var action = () => result.ThrowIfInvalid();
+
+        action.Should().NotThrow();
+    }
+
+    [Fact]
+    public void ThrowIfInvalid_WithErrors_ThrowsException()
+    {
+        var diagnostics = new OpenApiDiagnostic();
+        diagnostics.Errors.Add(new OpenApiError("", "Error"));
+        var stats = new OpenApiStats();
+        var result = new OpenApiValidationResult(diagnostics, stats);
+
+        var action = () => result.ThrowIfInvalid();
+
+        action.Should().Throw<OpenApiValidationException>();
+    }
+}

--- a/src/CurlGenerator.Tests/OperationNameGeneratorTests.cs
+++ b/src/CurlGenerator.Tests/OperationNameGeneratorTests.cs
@@ -1,0 +1,111 @@
+
+using CurlGenerator.Core;
+using FluentAssertions;
+using NSwag;
+
+namespace CurlGenerator.Tests;
+
+public class OperationNameGeneratorTests
+{
+    [Fact]
+    public void GetOperationName_ValidInput_ReturnsExpectedName()
+    {
+        var generator = new OperationNameGenerator();
+        var document = new OpenApiDocument();
+        document.Paths.Add("/my-path", new OpenApiPathItem
+        {
+            {
+                "get", new OpenApiOperation
+                {
+                    OperationId = "my-operation"
+                }
+            }
+        });
+
+        var operation = document.Paths["/my-path"]["get"];
+
+        var result = generator.GetOperationName(document, "/my-path", "get", operation);
+
+        result.Should().Be("GetMyOperation");
+    }
+
+    [Fact]
+    public void GetOperationName_WithException_ReturnsFallbackName()
+    {
+        var generator = new OperationNameGenerator();
+        var document = new OpenApiDocument();
+        document.Paths.Add("/my-path", new OpenApiPathItem
+        {
+            {
+                "get", new OpenApiOperation
+                {
+                    OperationId = null // This will cause an exception in the default generator
+                }
+            }
+        });
+
+        var operation = document.Paths["/my-path"]["get"];
+
+        var result = generator.GetOperationName(document, "/my-path", "get", operation);
+
+        result.Should().Be("GetMy-path");
+    }
+
+    [Fact]
+    public void CheckForDuplicateOperationIds_NoDuplicates_ReturnsFalse()
+    {
+        var generator = new OperationNameGenerator();
+        var document = new OpenApiDocument();
+        document.Paths.Add("/my-path", new OpenApiPathItem
+        {
+            {
+                "get", new OpenApiOperation
+                {
+                    OperationId = "my-operation"
+                }
+            }
+        });
+        document.Paths.Add("/my-other-path", new OpenApiPathItem
+        {
+            {
+                "get", new OpenApiOperation
+                {
+                    OperationId = "my-other-operation"
+                }
+            }
+        });
+
+        var result = generator.CheckForDuplicateOperationIds(document);
+
+        result.Should().BeFalse();
+    }
+
+    [Fact]
+    public void CheckForDuplicateOperationIds_WithDuplicates_ReturnsTrue()
+    {
+        var generator = new OperationNameGenerator();
+        var document = new OpenApiDocument();
+        document.Paths.Add("/my-path", new OpenApiPathItem
+        {
+            {
+                "get", new OpenApiOperation
+                {
+                    OperationId = "my-operation"
+                }
+            }
+        });
+        document.Paths.Add("/my-other-path", new OpenApiPathItem
+        {
+            {
+                "get", new OpenApiOperation
+                {
+                    OperationId = "my-operation"
+                }
+            }
+        });
+
+        var result = generator.CheckForDuplicateOperationIds(document);
+
+        result.Should().BeTrue();
+    }
+}

--- a/src/CurlGenerator.Tests/ScriptFileGeneratorTests.cs
+++ b/src/CurlGenerator.Tests/ScriptFileGeneratorTests.cs
@@ -1,0 +1,48 @@
+
+using CurlGenerator.Core;
+using CurlGenerator.Tests.Resources;
+using FluentAssertions;
+using FluentAssertions.Execution;
+
+namespace CurlGenerator.Tests;
+
+public class ScriptFileGeneratorTests
+{
+    [Fact]
+    public async Task Generate_WithBashScripts_GeneratesShFiles()
+    {
+        var json = EmbeddedResources.GetSwaggerPetstore(Samples.PetstoreJsonV3);
+        var swaggerFile = await TestFile.CreateSwaggerFile(json, "SwaggerPetstore.json");
+
+        var result = await ScriptFileGenerator.Generate(
+            new GeneratorSettings
+            {
+                OpenApiPath = swaggerFile,
+                GenerateBashScripts = true
+            });
+
+        using var scope = new AssertionScope();
+        result.Should().NotBeNull();
+        result.Files.Should().NotBeNullOrEmpty();
+        result.Files.Should().OnlyContain(f => f.Filename.EndsWith(".sh"));
+    }
+
+    [Fact]
+    public async Task Generate_WithNoServers_UsesBaseUrl()
+    {
+        var json = EmbeddedResources.GetSwaggerPetstore(Samples.PetstoreJsonV3);
+        var swaggerFile = await TestFile.CreateSwaggerFile(json, "SwaggerPetstore.json");
+
+        var result = await ScriptFileGenerator.Generate(
+            new GeneratorSettings
+            {
+                OpenApiPath = swaggerFile,
+                BaseUrl = "http://my-custom-base-url.com"
+            });
+
+        using var scope = new AssertionScope();
+        result.Should().NotBeNull();
+        result.Files.Should().NotBeNullOrEmpty();
+        result.Files.Should().Contain(f => f.Content.Contains("http://my-custom-base-url.com"));
+    }
+}

--- a/src/CurlGenerator.Tests/StringExtensionsTests.cs
+++ b/src/CurlGenerator.Tests/StringExtensionsTests.cs
@@ -1,0 +1,61 @@
+
+using CurlGenerator.Core;
+using FluentAssertions;
+
+namespace CurlGenerator.Tests;
+
+public class StringExtensionsTests
+{
+    [Theory]
+    [InlineData("kebab-case-string", "KebabCaseString")]
+    [InlineData("another-kebab-case.string", "AnotherKebabCase_string")]
+    [InlineData("single", "Single")]
+    public void ConvertKebabCaseToPascalCase_Should_Convert_Correctly(string input, string expected)
+    {
+        input.ConvertKebabCaseToPascalCase().Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("kebab-case-string", "kebab_case_string")]
+    [InlineData("another-kebab-case-string", "another_kebab_case_string")]
+    [InlineData("single", "single")]
+    public void ConvertKebabCaseToSnakeCase_Should_Convert_Correctly(string input, string expected)
+    {
+        input.ConvertKebabCaseToSnakeCase().Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("/route/to/resource", "RouteToResource")]
+    [InlineData("/another/route/to/another/resource", "AnotherRouteToAnotherResource")]
+    [InlineData("/single", "Single")]
+    public void ConvertRouteToCamelCase_Should_Convert_Correctly(string input, string expected)
+    {
+        input.ConvertRouteToCamelCase().Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("string", "String")]
+    [InlineData("anotherString", "AnotherString")]
+    [InlineData("s", "S")]
+    public void CapitalizeFirstCharacter_Should_Capitalize_Correctly(string input, string expected)
+    {
+        input.CapitalizeFirstCharacter().Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("space separated string", "SpaceSeparatedString")]
+    [InlineData("another space separated string", "AnotherSpaceSeparatedString")]
+    [InlineData("single", "Single")]
+    public void ConvertSpacesToPascalCase_Should_Convert_Correctly(string input, string expected)
+    {
+        input.ConvertSpacesToPascalCase().Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("string", "prefix", "prefixstring")]
+    [InlineData("prefixstring", "prefix", "prefixstring")]
+    public void Prefix_Should_Add_Prefix_Correctly(string input, string prefix, string expected)
+    {
+        input.Prefix(prefix).Should().Be(expected);
+    }
+}


### PR DESCRIPTION
This pull request introduces a comprehensive suite of unit tests for the `CurlGenerator` project, significantly improving test coverage for core functionality and validation logic. Additionally, it updates the project configuration to allow internal members to be accessed by the test assembly.

**Testing improvements:**

* Added tests for `OperationNameGenerator`, covering operation name generation, fallback behavior, and duplicate operation ID detection.
* Added tests for `ScriptFileGenerator`, ensuring correct file generation for Bash scripts and base URL handling.
* Added tests for string extension methods, verifying conversions between naming conventions and string manipulation utilities.
* Added tests for OpenAPI validation logic, including validation result correctness and exception throwing for invalid documents.
* Added tests for OpenAPI statistics collection, ensuring accurate counting of document elements.

**Project configuration:**

* Updated `CurlGenerator.Core.csproj` to make internals visible to the `CurlGenerator.Tests` assembly, enabling more thorough testing of internal logic.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* Tests
  * Added extensive unit tests covering OpenAPI document traversal/counting, validation result behaviors (success and error paths), operation-name generation and duplicate detection, script file generation (including Bash output and base URL handling), and multiple string utility conversions to improve coverage and reliability.

* Chores
  * Enabled test assembly access to internal members to allow deeper test validation without changing public APIs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->