### PR TITLE
Upgrade Spectre.Console.Cli from 0.53.0 to 0.55.0

### DIFF
--- a/src/CurlGenerator.Tests/GenerateCommandTests.cs
+++ b/src/CurlGenerator.Tests/GenerateCommandTests.cs
@@ -1,6 +1,7 @@
 ﻿using FluentAssertions;
 using CurlGenerator.Tests.Resources;
 using Spectre.Console.Cli;
+using System.Reflection;
 using Inline = Atc.Test.InlineAutoNSubstituteDataAttribute;
 
 namespace CurlGenerator.Tests;
@@ -44,7 +45,7 @@ public class GenerateCommandTests
         settings.OpenApiPath = await TestFile.CreateSwaggerFile(json, filename);
         settings.NoLogging = true;
 
-        (await sut.ExecuteAsync(context, settings, CancellationToken.None))
+        (await InvokeExecuteAsync(sut, context, settings, CancellationToken.None))
             .Should()
             .Be(0);
     }
@@ -69,7 +70,7 @@ public class GenerateCommandTests
         settings.NoLogging = true;
         settings.SkipValidation = true;
 
-        (await sut.ExecuteAsync(context, settings, CancellationToken.None))
+        (await InvokeExecuteAsync(sut, context, settings, CancellationToken.None))
             .Should()
             .Be(0);
     }
@@ -94,7 +95,7 @@ public class GenerateCommandTests
         settings.NoLogging = true;
         settings.SkipValidation = false;
 
-        (await sut.ExecuteAsync(context, settings, CancellationToken.None))
+        (await InvokeExecuteAsync(sut, context, settings, CancellationToken.None))
             .Should()
             .Be(0);
     }
@@ -117,7 +118,7 @@ public class GenerateCommandTests
         settings.OpenApiPath = url;
         settings.NoLogging = true;
 
-        (await sut.ExecuteAsync(context, settings, CancellationToken.None))
+        (await InvokeExecuteAsync(sut, context, settings, CancellationToken.None))
             .Should()
             .Be(0);
     }
@@ -133,8 +134,19 @@ public class GenerateCommandTests
         settings.OpenApiPath = url;
         settings.NoLogging = true;
 
-        (await sut.ExecuteAsync(context, settings, CancellationToken.None))
+        (await InvokeExecuteAsync(sut, context, settings, CancellationToken.None))
             .Should()
             .NotBe(0);
+    }
+    private static async Task<int> InvokeExecuteAsync(
+        GenerateCommand command,
+        CommandContext context,
+        Settings settings,
+        CancellationToken cancellationToken)
+    {
+        var method = typeof(GenerateCommand).GetMethod(
+            "ExecuteAsync",
+            BindingFlags.Instance | BindingFlags.NonPublic)!;
+        return await (Task<int>)method.Invoke(command, new object[] { context, settings, cancellationToken })!;
     }
 }

--- a/src/CurlGenerator/CurlGenerator.csproj
+++ b/src/CurlGenerator/CurlGenerator.csproj
@@ -16,7 +16,7 @@
         <PackageReference Include="Exceptionless" Version="6.1.0" />
         <PackageReference Include="Microsoft.OpenApi.OData" Version="3.2.0" />
         <PackageReference Include="Microsoft.OpenApi.YamlReader" Version="3.5.1" />
-        <PackageReference Include="Spectre.Console.Cli" Version="0.53.0" />
+        <PackageReference Include="Spectre.Console.Cli" Version="0.55.0" />
         <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.201" PrivateAssets="All" />
     </ItemGroup>
 

--- a/src/CurlGenerator/GenerateCommand.cs
+++ b/src/CurlGenerator/GenerateCommand.cs
@@ -12,7 +12,7 @@ public class GenerateCommand : AsyncCommand<Settings>
 {
     private static readonly string Crlf = Environment.NewLine;
 
-    public override async Task<int> ExecuteAsync(CommandContext context, Settings settings, CancellationToken cancellationToken)
+    protected override async Task<int> ExecuteAsync(CommandContext context, Settings settings, CancellationToken cancellationToken)
     {
         if (!settings.NoLogging)
             Analytics.Configure(); try


### PR DESCRIPTION
## Summary

Upgrades `Spectre.Console.Cli` from `0.53.x` to `0.55.0`.

## Breaking Changes Addressed

In `0.55.0`, `AsyncCommand<T>.ExecuteAsync()` changed from `public` to `protected`. This caused `CS0507` compiler errors.

### Changes
- **`.csproj`**: bumped `Spectre.Console.Cli` version to `0.55.0`
- **`GenerateCommand.cs`**: changed `public override` → `protected override` on `ExecuteAsync`
- **`GenerateCommandTests.cs`**: updated tests to call `ExecuteAsync` via reflection (required since the method is now `protected`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Dependencies**
  * Updated Spectre.Console.Cli to version 0.55.0.

* **Tests**
  * Enhanced test infrastructure with improved method invocation patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->